### PR TITLE
fixed 'language does not exist' exception

### DIFF
--- a/Resources/ZikulaUsersModule/views/Account/changeLanguage.html.twig
+++ b/Resources/ZikulaUsersModule/views/Account/changeLanguage.html.twig
@@ -8,7 +8,7 @@
     <div class="well">
         {{ form_start(form) }}
         {{ form_errors(form) }}
-        {{ form_row(form.language) }}
+        {{ form_row(form.locale) }}
         <div class="form-group">
             <div class="col-sm-offset-3 col-sm-9">
                 {{ form_widget(form.submit) }}


### PR DESCRIPTION
An exception ('language does not exist') occured when trying to switch the language in Zikula. In the original template the field is called 'locale', so I renamed it in this file to make it work again